### PR TITLE
Fix installing package with git+https

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
     name='brightpearl',
     version=VERSION,
 
-    packages=find_packages(),
+    packages=find_packages(exclude=("examples",)),
+    install_requires=["requests"],
 
     url='https://github.com/demystify-systems/brightpearl-python',
 


### PR DESCRIPTION
I'm not sure if you'd want to specify a minimum version for requests in setup.py, but this is the minimal set of changes that lets me install the package by pointing pip to the repository.